### PR TITLE
fix: Replace og-image.svg with og-image.png to prevent Twitter logo f…

### DIFF
--- a/components/SEOMeta.tsx
+++ b/components/SEOMeta.tsx
@@ -11,7 +11,7 @@ interface SEOMetaProps {
 export default function SEOMeta({ 
   title = 'Free Voice Productivity App | tickk - Speech Recognition Task Manager',
   description = 'Revolutionary free voice productivity app that transforms speech into organized tasks, notes, and calendar events using advanced natural language processing. No login required, works completely offline, complete privacy protection. 99% accurate speech recognition.',
-  image = '/og-image.svg',
+  image = '/og-image.png',
   url = 'https://tickk.app'
 }: SEOMetaProps) {
   const fullTitle = title.includes('tickk') ? title : `${title} | tickk`

--- a/pages/es/index.tsx
+++ b/pages/es/index.tsx
@@ -309,7 +309,7 @@ export default function SpanishApp() {
         <meta property="og:description" content="Volcado mental por voz → auto-organizado en tareas y notas. Gratis, código abierto, almacenamiento local." />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://tickk.app/es" />
-        <meta property="og:image" content="https://tickk.app/og-image.svg" />
+        <meta property="og:image" content="https://tickk.app/og-image.png" />
         <meta property="og:image:alt" content="tickk - Aplicación de Voz a Productividad" />
         <meta property="og:image:type" content="image/svg+xml" />
         <meta property="og:image:width" content="1200" />
@@ -323,7 +323,7 @@ export default function SpanishApp() {
         <meta name="twitter:creator" content="@tickkapp" />
         <meta name="twitter:title" content="tickk - Háblalo. Guárdalo. Ordénalo después." />
         <meta name="twitter:description" content="Volcado mental por voz → auto-organizado en tareas y notas. Gratis, código abierto, almacenamiento local." />
-        <meta name="twitter:image" content="https://tickk.app/og-image.svg" />
+        <meta name="twitter:image" content="https://tickk.app/og-image.png" />
         <meta name="twitter:image:alt" content="tickk - Aplicación de Voz a Productividad" />
         
         {/* Canonical and hreflang */}

--- a/pages/es/landing.tsx
+++ b/pages/es/landing.tsx
@@ -150,7 +150,7 @@ export default function LandingES() {
         <meta property="og:description" content="Aplicación revolucionaria gratuita de productividad por voz que transforma el habla en tareas organizadas y notas usando procesamiento avanzado de lenguaje natural. Sin registro requerido, funciona completamente offline, protección completa de privacidad. 99% de precisión en reconocimiento de voz." />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://tickk.app/es/landing" />
-        <meta property="og:image" content="https://tickk.app/og-image.svg" />
+        <meta property="og:image" content="https://tickk.app/og-image.png" />
         <meta property="og:image:alt" content="tickk - Aplicación de Voz a Productividad" />
         <meta property="og:image:type" content="image/svg+xml" />
         <meta property="og:image:width" content="1200" />
@@ -164,7 +164,7 @@ export default function LandingES() {
         <meta name="twitter:creator" content="@tickkapp" />
         <meta name="twitter:title" content="Aplicación Gratuita de Productividad por Voz | tickk - Gestor de Tareas por Reconocimiento de Voz" />
         <meta name="twitter:description" content="Aplicación revolucionaria gratuita de productividad por voz que transforma el habla en tareas organizadas y notas usando procesamiento avanzado de lenguaje natural. Sin registro requerido, funciona completamente offline, protección completa de privacidad. 99% de precisión en reconocimiento de voz." />
-        <meta name="twitter:image" content="https://tickk.app/og-image.svg" />
+        <meta name="twitter:image" content="https://tickk.app/og-image.png" />
         <meta name="twitter:image:alt" content="tickk - Aplicación de Voz a Productividad" />
         
         {/* Canonical and hreflang */}

--- a/pages/landing.tsx
+++ b/pages/landing.tsx
@@ -301,7 +301,7 @@ export default function Home() {
       className="min-h-screen bg-gradient-to-br from-orange-50 via-white to-gray-50   "
       seoTitle="tickk - Transform Voice into Organized Tasks"
       seoDescription="Privacy-first voice productivity app that converts speech into organized tasks and notes. Works offline and keeps your data secure."
-      seoImage="/og-image.svg"
+      seoImage="/og-image.png"
     >
         <div className="text-center">
           <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-orange-600 mb-4"></div>


### PR DESCRIPTION
…lash

- Updated Spanish pages (es/index.tsx, es/landing.tsx) to use PNG instead of SVG
- Fixed English landing page seoImage prop to use PNG
- Changed SEOMeta component default image from SVG to PNG
- Prevents large image flash during page load caused by SVG rendering before CSS constraints